### PR TITLE
Set fixed 1000px height for mobile app screens

### DIFF
--- a/client/global.css
+++ b/client/global.css
@@ -104,3 +104,19 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Fixed app height on phone screens */
+@layer utilities {
+  @media (max-width: 767px) {
+    html, body, #root {
+      height: 1000px !important;
+      min-height: 1000px !important;
+    }
+    .h-screen {
+      height: 1000px !important;
+    }
+    .min-h-screen {
+      min-height: 1000px !important;
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
The user requested to set a fixed height of 1000 pixels for the entire app on all phone screens to ensure consistent display across different mobile devices.

## Code changes
- Added CSS media query targeting mobile screens (max-width: 767px)
- Set fixed height and min-height of 1000px for html, body, and #root elements
- Override height utilities (.h-screen, .min-h-screen) to use 1000px on mobile
- Used !important declarations to ensure the fixed height takes precedenceTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/bc605c9cc8274250b1eec6f3c6ef62a1/echo-realm)

👀 [Preview Link](https://bc605c9cc8274250b1eec6f3c6ef62a1-echo-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bc605c9cc8274250b1eec6f3c6ef62a1</projectId>-->
<!--<branchName>echo-realm</branchName>-->