### PR TITLE
Limit vertical scaling on large screens with max height

### DIFF
--- a/client/global.css
+++ b/client/global.css
@@ -120,3 +120,16 @@
     }
   }
 }
+
+/* Cap app height on larger screens to avoid vertical scaling */
+@layer utilities {
+  @media (min-width: 768px) {
+    .h-screen {
+      height: min(100vh, 1000px) !important;
+    }
+    .min-h-screen {
+      min-height: min(100vh, 1000px) !important;
+      height: min(100vh, 1000px) !important;
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
Prevent the website from scaling vertically on large screens by implementing a maximum height constraint. This ensures the layout remains optimized for horizontal scaling only, improving the user experience on big screens.

## Code changes
- Added CSS media query for screens wider than 768px
- Applied `min(100vh, 1000px)` height constraint to `.h-screen` and `.min-h-screen` classes
- Used `!important` declarations to override existing height styles
- Capped maximum height at 1000px to prevent excessive vertical expansionTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/bc605c9cc8274250b1eec6f3c6ef62a1/neon-studio)

👀 [Preview Link](https://bc605c9cc8274250b1eec6f3c6ef62a1-neon-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bc605c9cc8274250b1eec6f3c6ef62a1</projectId>-->
<!--<branchName>neon-studio</branchName>-->